### PR TITLE
Fix error when vim is launched from a shell whose Python environment doesn't have Jupyter installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,59 @@ then run:
 Once help tags have been generated, you can view the manual with
 `:help jupyter-vim`.
 
+In order for this plugin to work, **you must have Jupyter installed** in the
+Python environment that vim's `pythonx` command uses.  If either:
+
+* you use a Python environment manager such as `virtualenv`, and thus need
+  Jupyter to be present no matter which environment is loaded from the shell
+  you open vim from, or
+* you only use one Python environment but you don't want to install Jupyter
+  system-wide for whatever reason,
+
+then the easiest way to meet the Jupyter requirement is to configure vim to
+load a designated virtualenv at startup.  This is just to allow vim to call the
+Jupyter client; you can run your Jupyter server in whatever Python environment
+you want.  From vim, run
+
+```vim
+    :pythonx import sys; print(sys.version)
+```
+
+This will tell you whether `pythonx` is using Python 2 or Python 3.  (Or, see
+`:help python_x` if you'd like to tweak your `pythonx` settings.)  Create a
+virtualenv with that python version, for example
+
+```bash
+    $ virtualenv -p /usr/bin/python2.7 /path/to/my/new/vim_virtualenv
+```
+
+or
+
+```bash
+    $ virtualenv -p /usr/bin/python3 /path/to/my/new/vim_virtualenv
+```
+
+and then install Jupyter in that environment:
+
+```bash
+    $ source /path/to/my/new/vim_virtualenv
+    $ pip install jupyter
+```
+
+Finally, tell vim to load this virtualenv at startup by adding these lines to
+your vimrc:
+
+```vim
+    " Always use the same virtualenv for vim, regardless of what Python
+    " environment is loaded in the shell from which vim is launched
+    let g:vim_virtualenv_path = '/path/to/my/new/vim_virtualenv'
+    if exists('g:vim_virtualenv_path')
+        pythonx import os; import vim
+        pythonx activate_this = os.path.join(vim.eval('g:vim_virtualenv_path'), 'bin/activate_this.py')
+        pythonx with open(activate_this) as f: exec(f.read(), {'__file__': activate_this})
+    endif
+```
+
 ## Quickstart
 To begin:
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ or
 and then install Jupyter in that environment:
 
 ```bash
-    $ source /path/to/my/new/vim_virtualenv
+    $ source /path/to/my/new/vim_virtualenv/bin/activate
     $ pip install jupyter
 ```
 

--- a/autoload/jupyter.vim
+++ b/autoload/jupyter.vim
@@ -12,6 +12,11 @@
 function! s:init_python() abort 
     let s:init_outcome = 0
     let init_lines = [
+          \ 'import sys; import os; import vim',
+          \ 'vim_path, _ = os.path.split(vim.eval("expand(''<sfile>:p:h'')"))',
+          \ 'vim_pythonx_path = os.path.join(vim_path, "pythonx")',
+          \ 'if vim_pythonx_path not in sys.path:',
+          \ '    sys.path.append(vim_pythonx_path)',
           \ 'import vim',
           \ 'try:',
           \ '    import jupyter_vim',

--- a/autoload/jupyter.vim
+++ b/autoload/jupyter.vim
@@ -17,7 +17,6 @@ function! s:init_python() abort
           \ 'vim_pythonx_path = os.path.join(vim_path, "pythonx")',
           \ 'if vim_pythonx_path not in sys.path:',
           \ '    sys.path.append(vim_pythonx_path)',
-          \ 'import vim',
           \ 'try:',
           \ '    import jupyter_vim',
           \ 'except Exception as exc:',

--- a/pythonx/jupyter_vim.py
+++ b/pythonx/jupyter_vim.py
@@ -18,7 +18,10 @@ import signal
 import sys
 
 import textwrap
-from queue import Empty
+try:
+    from queue import Empty
+except ImportError:
+    from Queue import Empty
 
 _install_instructions = """You *must* install the jupyter package into the
 Python that your vim is linked against. If you are seeing this message, this

--- a/pythonx/jupyter_vim.py
+++ b/pythonx/jupyter_vim.py
@@ -34,13 +34,13 @@ Python.
 
 try:
     import jupyter
-except ImportError:
-    raise ImportError("Could not find kernel. " + _install_instructions)
+except ImportError as e:
+    raise ImportError("Could not find kernel. " + _install_instructions, e)
 
 try:
     import vim
-except ImportError:
-    raise ImportError('vim module only available within vim!')
+except ImportError as e:
+    raise ImportError('vim module only available within vim!', e)
 
 #------------------------------------------------------------------------------
 #        Read global configuration variables

--- a/pythonx/jupyter_vim.py
+++ b/pythonx/jupyter_vim.py
@@ -26,8 +26,11 @@ except ImportError:
 _install_instructions = """You *must* install the jupyter package into the
 Python that your vim is linked against. If you are seeing this message, this
 usually means either: 
-    (1) installing Jupyter using the system Python that vim is using, or 
-    (2) recompiling Vim against the Python where you already have Jupyter
+    (1) configuring vim to automatically load a virtualenv that has Jupyter
+        installed and whose Python interpreter is the same version that your
+        vim is compiled against
+    (2) installing Jupyter using the system Python that vim is using, or
+    (3) recompiling Vim against the Python where you already have Jupyter
         installed. 
 This is only a requirement to allow Vim to speak with a Jupyter kernel using
 Jupyter's own machinery. It does *not* mean that the Jupyter instance with


### PR DESCRIPTION
# Summary

Fixes https://github.com/wmvanvliet/jupyter-vim/issues/18.

Currently vim will have a (non-fatal) error at startup if this plugin is installed and vim is launched from a shell whose Python environment does not have Jupyter installed.  This can become annoying if the user switches between virtualenvs (or similar) frequently.  This PR adds instructions for how to configure vim to always use the same virtualenv regardless of what Python environment was present in the shell it was launched from, and makes some minor changes to the plugin to support that solution.