### PR TITLE
Remove block=False from get_msgs call

### DIFF
--- a/pythonx/jupyter_vim.py
+++ b/pythonx/jupyter_vim.py
@@ -270,7 +270,7 @@ def handle_messages():
     See also: <http://jupyter-client.readthedocs.io/en/stable/messaging.html>
     """
     io_pub = []
-    msgs = kc.iopub_channel.get_msgs(block=False)
+    msgs = kc.iopub_channel.get_msgs()
     for msg in msgs:
         s = ''
         if 'msg_type' not in msg['header']:


### PR DESCRIPTION
get_msgs doesn't take such a parameter - it doesn't block.

This addresses broesler/jupyter-vim#13

I tested this by "let g:jupyter_monitor_console=1". Before this change I'd get an error message when sending to jupyter. With this change it works as expected without any error message.