### PR TITLE
Better error handling

### DIFF
--- a/pythonx/jupyter_vim.py
+++ b/pythonx/jupyter_vim.py
@@ -270,7 +270,7 @@ def handle_messages():
     See also: <http://jupyter-client.readthedocs.io/en/stable/messaging.html>
     """
     io_pub = []
-    msgs = kc.iopub_channel.get_msgs(block=False)
+    msgs = kc.iopub_channel.get_msgs()
     for msg in msgs:
         s = ''
         if 'msg_type' not in msg['header']:


### PR DESCRIPTION
Before this change I would get this error message with the jupyter-vim plugin when starting vim, if jupyter was not installed: https://gist.github.com/tcmulcahy/a38d65c009947dde08ea506ac74c976a
With this change, the error message is improved: https://gist.github.com/tcmulcahy/5edd8cf18c1d4bba32c510cde9b142c4

I've also made the error handling as robust as possible, so that just about any problem that happens while running python code will be printed to stdout.